### PR TITLE
Order of gcc args wrong, linking fails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,6 @@ all: xsetprop
 	@echo "[DONE]"
 
 xsetprop: xsetprop.c
-	gcc `pkg-config --libs --cflags x11 xmu` $^ -o $@
+	gcc $^ -o $@ `pkg-config --libs --cflags x11 xmu`
 
 ### Makefile ends here


### PR DESCRIPTION
Hi!

In gcc call, moving -l options (generated by pkg-config) to end of command line so they are found when linking

The -l options from pkg-config need to be at the end of the gcc command line in Makefile
to be in effect, otherwise the linking fails.
I got an error like below when compiling:

$ make
gcc `pkg-config --libs --cflags x11 xmu` xsetprop.c -o xsetprop
/tmp/ccQbRUHw.o: In function `splits_to_atomsarray':
xsetprop.c:(.text+0x349): undefined reference to`XInternAtom'
...[some similar lines](on Ubuntu 12.10)

Best Regards,
Volker
